### PR TITLE
Show Solana token holders in PS4 UI

### DIFF
--- a/assets/js/holders.js
+++ b/assets/js/holders.js
@@ -1,0 +1,56 @@
+const MINT_ADDRESS = 'YOUR_TOKEN_MINT_ADDRESS';
+const REFRESH_INTERVAL = 15000; // milliseconds
+
+async function fetchHolders() {
+  try {
+    const url = `https://public-api.solscan.io/token/holders?tokenAddress=${MINT_ADDRESS}&offset=0&size=50`;
+    const response = await fetch(url);
+    if (!response.ok) return;
+    const holders = await response.json();
+    updateHolders(holders.data || holders); // solscan returns {data: []}
+  } catch (e) {
+    console.error('Failed to fetch holders', e);
+  }
+}
+
+function shortAddress(addr) {
+  return addr.slice(0, 4) + '...' + addr.slice(-4);
+}
+
+function updateHolders(list) {
+  const container = document.getElementById('games');
+  container.style.width = `${list.length * 12}em`;
+  container.innerHTML = '';
+  list.forEach((holder, idx) => {
+    const a = document.createElement('a');
+    a.href = '#';
+
+    const square = document.createElement('div');
+    square.className = 'squareGame animated bounceInLeft';
+
+    const img = document.createElement('div');
+    img.className = 'imgGame';
+    img.tabIndex = 0;
+    img.style.backgroundImage = `url(https://api.dicebear.com/6.x/identicon/svg?seed=${holder.owner || holder.address})`;
+
+    const text = document.createElement('div');
+    text.className = 'gameText';
+    text.textContent = shortAddress(holder.owner || holder.address);
+
+    const title = document.createElement('span');
+    title.className = 'gameTitle';
+    title.textContent = `#${idx + 1}`;
+
+    square.appendChild(img);
+    square.appendChild(text);
+    square.appendChild(title);
+    a.appendChild(square);
+    container.appendChild(a);
+  });
+  if (typeof window.updateFocusableList === 'function') {
+    window.updateFocusableList();
+  }
+}
+
+fetchHolders();
+setInterval(fetchHolders, REFRESH_INTERVAL);

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -49,6 +49,10 @@ const rAF = window.mozRequestAnimationFrame || window.requestAnimationFrame;
 let current = 1;
 let focusable = document.querySelectorAll('a.href, [tabindex], [tabindex]:not([tabindex="-1"])');
 
+function updateFocusableList() {
+  focusable = document.querySelectorAll("a[href], [tabindex]:not([tabindex='-1'])");
+}
+window.updateFocusableList = updateFocusableList;
 window.addEventListener('gamepadconnected', function (e) {
     updateLoop();
 });

--- a/index.html
+++ b/index.html
@@ -35,121 +35,6 @@
                 </header>
       
                 <div id="games">
-                    <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame ps" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Playstation Store</span>
-                        <div id="store">
-				<div id="god" class="storeGame"></div>
-				<div id="raider" class="storeGame"></div>
-				<div id="codi" class="storeGame"></div>
-				<div id="mafia" class="storeGame"></div>
-				<div id="destiny" class="storeGame"></div>
-				<div id="bt1" class="storeGame"></div>
-				<div id="lg" class="storeGame"></div>
-				<div id="per" class="storeGame"></div>
-                        </div>
-                    </div>
-                    </a>
-                    <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame new" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">What's New</span>
-                    </div>
-                    </a>
-                    <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame last" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">The Last Of Us Part II</span>
-                    </div>
-                    </a>
-                    <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame detroit" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Detroit: Become Human</span>
-                    </div>
-                    </a>
-                    <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame spiderman" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Spider-Man</span>
-                    </div>
-                    </a>
-                        <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame battle" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Battlefield 1</span>
-                    </div>
-                        </a>
-                        <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame death" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Death Stranding</span>
-                    </div>
-                        </a>
-                        <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame red" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Red Dead Redemption 2</span>
-                    </div>
-                        </a>
-                    <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame elden" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Elden Ring</span>
-                    </div>
-                    </a>
-                    <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame cod" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Call Of Duty: Black Ops III</span>
-                    </div>
-                    </a>
-                    <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame jedi" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Jedi: Fallen Order</span>
-                    </div>
-                    </a>
-                        <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame fifa" tabindex="0"></div>
-                        <div class="gameText">Start</div>
-                        <span class="gameTitle">Fifa 23</span>
-                    </div>
-                        </a>
-                        <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame youtube" tabindex="0"></div>
-                        <div class="gameText">Open</div>
-                        <span class="gameTitle">Youtube</span>
-                    </div>
-                         </a>
-                        <a href="#">
-                    <div class="squareGame animated bounceInLeft">
-                        <div class="imgGame settings" tabindex="0"></div>
-                        <div class="gameText">Open</div>
-                        <span class="gameTitle">Settings</span>
-                    </div>
-                        </a>
-                        <a href="#">
-                    <div class="squareGame animated bounceInLeft" id="shutdown">
-                        <div class="imgGame off" tabindex="0"></div>
-                        <div class="gameText">Shutdown</div>
-                        <span class="gameTitle">Turn Off</span>
-                    </div>
-                        </a>
                 </div>
 
                 <div class='box'>
@@ -161,5 +46,6 @@
 
     <!--========== JAVASCRIPT ===========-->
     <script  src="./assets/js/script.js"></script>
+    <script src="./assets/js/holders.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove hard-coded game grid
- fetch token holder data from Solscan
- render each holder as a PS4-style tile with an identicon
- refresh the list automatically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e6c602e448322a51c8e5ec4f19bca